### PR TITLE
Fix cookie spoofing and improve Spotify auth error

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -3,8 +3,10 @@ from fastapi import APIRouter, Request, Query, HTTPException
 from fastapi.responses import RedirectResponse, HTMLResponse, JSONResponse
 import base64, json, os
 import spotipy
+from spotipy.exceptions import SpotifyException
 
 from services.spotify_auth import get_spotify_oauth
+from services.cookie import encode, decode
 from db.mongo import users_collection
 from services.token import refresh_user_token
 
@@ -26,7 +28,9 @@ def safe_b64decode(data: str):
 @router.get("/login")
 async def login():
     # Redirect URI for frontend to land on after auth finishes
-    frontend_redirect_uri = PRO_BASE_URL + "/home" if not IS_DEV else DEV_BASE_URL + "/home"
+    frontend_redirect_uri = (
+        PRO_BASE_URL + "/home" if not IS_DEV else DEV_BASE_URL + "/home"
+    )
 
     # Encode that into state so /callback knows where to send user
     state_payload = json.dumps({"redirect_uri": frontend_redirect_uri})
@@ -66,6 +70,14 @@ async def callback(request: Request):
         sp = spotipy.Spotify(auth=token_info["access_token"])
         profile = sp.current_user()
         user_id = profile.get("id")
+    except SpotifyException as e:
+        print(f"❌ Token exchange or user fetch failed: {e}")
+        if e.http_status == 403:
+            raise HTTPException(
+                status_code=403,
+                detail="Spotify access forbidden: user may not be registered in dashboard",
+            )
+        raise HTTPException(status_code=500, detail=f"Internal callback error: {e}")
     except Exception as e:
         print(f"❌ Token exchange or user fetch failed: {e}")
         raise HTTPException(status_code=500, detail=f"Internal callback error: {e}")
@@ -93,7 +105,7 @@ async def callback(request: Request):
 
     response.set_cookie(
         key="sinatra_user_id",
-        value=user_id,
+        value=encode(user_id),
         httponly=True,
         secure=not IS_DEV,
         samesite="None" if not IS_DEV else "Lax",
@@ -131,10 +143,17 @@ def logout_user():
     )
     return response
 
+
 @router.get("/whoami")
 def whoami(request: Request):
     all_cookies = request.cookies
-    user_id = all_cookies.get("sinatra_user_id")
+    cookie_val = all_cookies.get("sinatra_user_id")
+    user_id = None
+    if cookie_val:
+        try:
+            user_id = decode(cookie_val)
+        except Exception:
+            user_id = None
 
     print("🔍 /whoami DEBUG:")
     print("🧁  All cookies received:", dict(all_cookies))

--- a/backend/api/cookie.py
+++ b/backend/api/cookie.py
@@ -2,6 +2,7 @@
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import JSONResponse
 from models.shared import CookiePayload
+from services.cookie import encode
 
 router = APIRouter(tags=["cookie"])
 
@@ -14,7 +15,7 @@ def set_cookie(data: CookiePayload):
     response = JSONResponse({"message": "cookie set"})
     response.set_cookie(
         key="sinatra_user_id",
-        value=data.user_id,
+        value=encode(data.user_id),
         httponly=True,
         secure=True,
         samesite="None",

--- a/backend/api/dashboard.py
+++ b/backend/api/dashboard.py
@@ -3,17 +3,15 @@ from fastapi import APIRouter, Request, HTTPException
 from db.mongo import users_collection
 from api.genres import get_genres
 from services.music.track_utils import apply_meta_gradients
+from services.cookie import get_user_id_from_request
 
 router = APIRouter(tags=["dashboard"])
 
 
 @router.get("/dashboard")
 def get_dashboard(request: Request):
-    user_id = request.cookies.get("sinatra_user_id")
+    user_id = get_user_id_from_request(request)
     print(f"🍪 /dashboard cookie received: sinatra_user_id = {user_id}")
-
-    if not user_id:
-        raise HTTPException(status_code=401, detail="Not logged in")
 
     doc = users_collection.find_one({"user_id": user_id})
     if not doc:

--- a/backend/api/genres.py
+++ b/backend/api/genres.py
@@ -10,6 +10,7 @@ from services.music.wizard import get_gradient_for_genre
 from services.music.meta_gradients import gradients
 from fastapi import Request
 from services.token import get_token_by_user_id
+from services.cookie import get_user_id_from_request
 
 
 import os, json, traceback
@@ -26,9 +27,7 @@ GENRE_MAP_PATH = (
 
 @router.get("/genres")
 def get_genres(request: Request, refresh: bool = False):
-    user_id = request.cookies.get("sinatra_user_id")
-    if not user_id:
-        raise HTTPException(status_code=400, detail="Missing sinatra_user_id cookie")
+    user_id = get_user_id_from_request(request)
     try:
         access_token = get_token(request)
         return analyze_user_genres(user_id, access_token)

--- a/backend/api/playlists.py
+++ b/backend/api/playlists.py
@@ -11,6 +11,7 @@ from typing import List
 import spotipy
 from fastapi import Request, Depends
 from services.token import get_token
+from services.cookie import get_user_id_from_request
 from models.playlists import FeaturedPlaylistsUpdateRequest
 
 from db.mongo import users_collection, playlists_collection
@@ -57,9 +58,7 @@ async def add_playlists(
     request: Request,
     access_token: str = Depends(get_token),
 ):
-    user_id = request.cookies.get("sinatra_user_id")
-    if not user_id:
-        raise HTTPException(status_code=400, detail="Missing sinatra_user_id cookie")
+    user_id = get_user_id_from_request(request)
 
     try:
         body = await request.json()
@@ -107,9 +106,7 @@ async def delete_playlists(
     request: Request,
     access_token: str = Depends(get_token),
 ):
-    user_id = request.cookies.get("sinatra_user_id")
-    if not user_id:
-        raise HTTPException(status_code=400, detail="Missing sinatra_user_id cookie")
+    user_id = get_user_id_from_request(request)
 
     try:
         body = await request.json()

--- a/backend/api/user.py
+++ b/backend/api/user.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, Request, HTTPException, Query, Body
 from fastapi.responses import JSONResponse
 from db.mongo import users_collection, playlists_collection
 from services.token import get_token
+from services.cookie import get_user_id_from_request
 from datetime import datetime
 import spotipy
 
@@ -11,9 +12,7 @@ router = APIRouter(tags=["user"])
 
 @router.get("/me")
 def get_me(request: Request):
-    user_id = request.cookies.get("sinatra_user_id")
-    if not user_id:
-        raise HTTPException(status_code=401, detail="Missing sinatra_user_id cookie")
+    user_id = get_user_id_from_request(request)
 
     user = users_collection.find_one({"user_id": user_id})
 

--- a/backend/services/cookie.py
+++ b/backend/services/cookie.py
@@ -1,0 +1,38 @@
+import os
+import hmac
+import hashlib
+import base64
+from fastapi import Request, HTTPException
+
+SECRET = os.getenv("COOKIE_SECRET", "dev-secret")
+
+
+def _sign(value: str) -> str:
+    sig = hmac.new(SECRET.encode(), value.encode(), hashlib.sha256).digest()
+    return base64.urlsafe_b64encode(sig).decode().rstrip("=")
+
+
+def encode(user_id: str) -> str:
+    signature = _sign(user_id)
+    return f"{user_id}.{signature}"
+
+
+def decode(cookie_value: str) -> str:
+    try:
+        user_id, signature = cookie_value.rsplit(".", 1)
+    except ValueError:
+        raise ValueError("Invalid cookie format")
+    expected = _sign(user_id)
+    if not hmac.compare_digest(signature, expected):
+        raise ValueError("Invalid cookie signature")
+    return user_id
+
+
+def get_user_id_from_request(request: Request) -> str:
+    cookie = request.cookies.get("sinatra_user_id")
+    if not cookie:
+        raise HTTPException(status_code=401, detail="Missing sinatra_user_id cookie")
+    try:
+        return decode(cookie)
+    except ValueError:
+        raise HTTPException(status_code=401, detail="Invalid sinatra_user_id cookie")

--- a/backend/services/token.py
+++ b/backend/services/token.py
@@ -2,12 +2,11 @@
 from fastapi import HTTPException, Request, Depends
 from services.spotify_auth import get_spotify_oauth
 from db.mongo import users_collection
+from services.cookie import get_user_id_from_request
 
 
 def get_token(request: Request) -> str:
-    user_id = request.cookies.get("sinatra_user_id")
-    if not user_id:
-        raise HTTPException(status_code=401, detail="Missing sinatra_user_id cookie")
+    user_id = get_user_id_from_request(request)
 
     user = users_collection.find_one({"user_id": user_id})
     if not user:


### PR DESCRIPTION
## Summary
- sign `sinatra_user_id` cookies with HMAC and validate on every request
- add helper to parse signed cookies
- update all API routes to use the signed cookie helper
- surface a clearer 403 error when Spotify rejects new users

## Testing
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6857c213afb083339a6a84b7a19c38e7